### PR TITLE
Wrong Content-Length when sending non-ascii chars in the body

### DIFF
--- a/lib/ftw/http/message.rb
+++ b/lib/ftw/http/message.rb
@@ -62,7 +62,7 @@ module FTW::HTTP::Message
     if (message_body.respond_to?(:read) or message_body.respond_to?(:each)) and
       headers["Transfer-Encoding"] = "chunked"
     else
-      headers["Content-Length"] = message_body.length
+      headers["Content-Length"] = message_body.bytesize
     end
   end # def body=
 


### PR DESCRIPTION
I found an issue in FTW when using the `elasticsearch_http` output in LogStash.

The Content-Length is filled with the number of chars instead of the actual byte size which make the other side cut the request's body by the difference when it contains non-ascii chars.

Examples with the char "…" (HORIZONTAL ELLIPSIS)

```
"…".length -> 1
"…".bytesize -> 3
```

```
~ % curl -v -XPOST -d"…" http://127.0.0.1:6543/
* About to connect() to 127.0.0.1 port 6543 (#0)
*   Trying 127.0.0.1...
* Connected to 127.0.0.1 (127.0.0.1) port 6543 (#0)
> POST / HTTP/1.1
> User-Agent: curl/7.29.0
> Host: 127.0.0.1:6543
> Accept: */*
> Content-Length: 3
> Content-Type: application/x-www-form-urlencoded
> 
* upload completely sent off: 3 out of 3 bytes
```
