### PR TITLE
Allow FTW to use the same version of backports that the current FPM requires

### DIFF
--- a/ftw.gemspec
+++ b/ftw.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency("cabin", ">0") # for logging, latest is fine for now
   spec.add_dependency("http_parser.rb", "0.5.3") # for http request/response parsing
   spec.add_dependency("addressable")  # because stdlib URI is terrible
-  spec.add_dependency("backports", "2.3.0") # for hacking stuff into ruby <1.9
+  spec.add_dependency("backports", ">= 2.3.0") # for hacking stuff into ruby <1.9
   spec.add_development_dependency("minitest", ">0") # for unit tests, latest of this is fine
 
   spec.files = files


### PR DESCRIPTION
Fixes #10
