### PR TITLE
Make websocket more RFC friendly ( case insensitive)

### DIFF
--- a/lib/ftw/websocket.rb
+++ b/lib/ftw/websocket.rb
@@ -102,8 +102,8 @@ class FTW::WebSocket
   def handshake_ok?(response)
     # See RFC6455 section 4.2.2
     return false unless response.status == 101 # "Switching Protocols"
-    return false unless response.headers.get("upgrade") == "websocket"
-    return false unless response.headers.get("connection") == "Upgrade"
+    return false unless response.headers.get("upgrade").downcase == "websocket"
+    return false unless response.headers.get("connection").downcase == "upgrade"
 
     # Now verify Sec-WebSocket-Accept. It should be the SHA-1 of the
     # Sec-WebSocket-Key (in base64) + WEBSOCKET_ACCEPT_UUID


### PR DESCRIPTION
I found a websocket server that responded
  Upgrade: WebSocket
and made FTW fail.

Make websocket more RFC friendly. 
RFC6455,Page 18:
The client MUST validate the server's response as follows:
(...)
2.  If the response lacks an |Upgrade| header field or the |Upgrade|
    header field contains a value that is not an ASCII case-
    insensitive match for the value "websocket", the client MUST
    _Fail the WebSocket Connection_.
1.  If the response lacks a |Connection| header field or the
   |Connection| header field doesn't contain a token that is an
   ASCII case-insensitive match for the value "Upgrade", the client
   MUST _Fail the WebSocket Connection_.
