### PR TITLE
! Fix websocket writer not correctly serializing UTF-8 text

### DIFF
--- a/lib/ftw/websocket/writer.rb
+++ b/lib/ftw/websocket/writer.rb
@@ -68,8 +68,8 @@ class FTW::WebSocket::Writer
 
   # Pack the payload.
   def pack_payload(data, pack, text, mode)
-    pack_maskbit_and_length(data, pack, text.length, mode)
-    pack_extended_length(data, pack, text.length) if text.length >= 126
+    pack_maskbit_and_length(data, pack, text.bytesize, mode)
+    pack_extended_length(data, pack, text.bytesize) if text.bytesize >= 126
     if mode == :client
       mask_key = [rand(1 << 32)].pack("Q")
       pack_mask(data, pack, mask_key)


### PR DESCRIPTION
While debugging the logstash setup at my workplace I have encountered a problem when sending JSON containing UTF-8 multibyte characters via the websocket output. The problem was a missing '}' at the end of the JSON data which was triggered by a multibyte character in one of the fields.

Since this a rather plain "byte size != string length" problem which is easily overlooked when serializing strings, I went spelunking for the culprit.

After digging through the dependencies I ended up at ruby-ftw and I was able to improvise a patch. I have absolutely no experience with Ruby, the patch is made up of 50% googling and 50% guessing. It works for our setup, but I do not know enough ruby to set up unit tests. So I understand if the patch will not be pulled as is. At least it can serve as a reasonably detailed bug report.
