### PR TITLE
Disable connections after EOFerror and clean on next fetch

### DIFF
--- a/lib/ftw/connection.rb
+++ b/lib/ftw/connection.rb
@@ -244,6 +244,8 @@ class FTW::Connection
         data << @read_buffer
         return data
       rescue EOFError => e
+        @socket.close
+        @connected = false
         raise e
       end
     else

--- a/lib/ftw/pool.rb
+++ b/lib/ftw/pool.rb
@@ -40,6 +40,7 @@ class FTW::Pool
   #     end
   def fetch(identifier, &default_block)
     @lock.synchronize do
+      @pool[identifier].delete_if { |o| o.available? && !o.connected? }
       object = @pool[identifier].find { |o| o.available? }
       return object if !object.nil?
     end


### PR DESCRIPTION
A read_body on a Request can fail w/ EOFerror, leaving the Connection up, marked on the pool, but unusable.
This patch closes the socket and marks the connection as disconnected. On the next fetch from pool all marked connections that are not connected will be deleted.
