### PR TITLE
Fix bug unpacking IPv6 addresses.

### DIFF
--- a/lib/ftw/dns/dns.rb
+++ b/lib/ftw/dns/dns.rb
@@ -34,7 +34,7 @@ class FTW::DNS::DNS
     if address.length == 16
       # Unpack 16 bit chunks, convert to hex, join with ":"
       address.unpack("n8").collect { |p| p.to_s(16) } \
-        .join(":").sub(/(?:0:(?:0:)+)/, ":")
+        .join(":").sub(/(?:^|:)0:(?:0:)+/, "::")
     else 
       # assume ipv4
       # Per the following sites, "::127.0.0.1" is valid and correct


### PR DESCRIPTION
Cases that didn't work:
  localhost (::1)
  divisible by 10 (70::1)
