### PR TITLE
support non ascii inputs in write_http_body

### DIFF
--- a/lib/ftw/protocol.rb
+++ b/lib/ftw/protocol.rb
@@ -109,7 +109,7 @@ module FTW::Protocol
   def write_all(io, string)
     while string.bytesize > 0
       w = io.write(string)
-      string = string[w..-1]
+      string = string.byteslice(w..-1)
     end
   end # def write_all
 

--- a/test/ftw/protocol.rb
+++ b/test/ftw/protocol.rb
@@ -76,4 +76,17 @@ describe FTW::Protocol do
     assert_equal( output.io.string, "12\r\nSome example input\r\n0\r\n\r\n")
   end
 
+  test "writing non ascii characters" do
+    protocol = Object.new
+    protocol.extend FTW::Protocol
+
+    output = StringIO.new
+    input  = "è".force_encoding(Encoding::UTF_8)
+
+    protocol.write_http_body(input, output, true)
+
+    output.rewind
+    assert_equal( output.string, "2\r\nè\r\n0\r\n\r\n")
+  end
+
 end


### PR DESCRIPTION
this makes `write_all` behave correctly when dealing will strings that have multiple bytes per character (like in UTF-8).
