### PR TITLE
Handle duplicate headers sent from a client

### DIFF
--- a/lib/ftw/http/headers.rb
+++ b/lib/ftw/http/headers.rb
@@ -117,7 +117,7 @@ class FTW::HTTP::Headers
   def each(&block)
     @headers.each do |field_name, field_value|
       if field_value.is_a?(Array)
-        field_value.map { |value| yield field_name, v }
+        field_value.map { |value| yield field_name, value }
       else
         yield field_name, field_value
       end

--- a/test/ftw/http/headers.rb
+++ b/test/ftw/http/headers.rb
@@ -47,4 +47,13 @@ describe FTW::HTTP::Headers do
     @headers.remove("foo", "two")
     assert_equal("one", @headers.get("foo"))
   end
+
+  test "duplicate headers return multiple key value pairs" do
+    @headers.add("foo", "bar")
+    @headers.add("foo", "fizz")
+    @headers.each do |key, value|
+      assert_equal("foo", key)
+      assert( value == "bar" || value == "fizz")
+    end
+  end
 end # describe FTW::HTTP::Headers


### PR DESCRIPTION
When a client sends duplicate headers to the FTW Web server in logstash/kibana, the process dies with the following error:

```
/opt/logstash/vendor/bundle/jruby/1.9/gems/ftw-0.0.39/lib/rack/handler/ftw.rb:107:in `run'
NameError: undefined local variable or method `v' for #<FTW::HTTP::Headers:0x5b9dd081>
               each at /opt/logstash/vendor/bundle/jruby/1.9/gems/ftw-0.0.39/lib/ftw/http/headers.rb:120
                map at org/jruby/RubyArray.java:2409
               each at /opt/logstash/vendor/bundle/jruby/1.9/gems/ftw-0.0.39/lib/ftw/http/headers.rb:120
               each at org/jruby/RubyHash.java:1339
               each at /opt/logstash/vendor/bundle/jruby/1.9/gems/ftw-0.0.39/lib/ftw/http/headers.rb:118
     handle_request at /opt/logstash/vendor/bundle/jruby/1.9/gems/ftw-0.0.39/lib/rack/handler/ftw.rb:178
  handle_connection at /opt/logstash/vendor/bundle/jruby/1.9/gems/ftw-0.0.39/lib/rack/handler/ftw.rb:136
  handle_connection at /opt/logstash/lib/logstash/kibana.rb:12
                run at /opt/logstash/vendor/bundle/jruby/1.9/gems/ftw-0.0.39/lib/rack/handler/ftw.rb:10
```

This pull request fixes this issue.
