### PR TITLE
bump http_parser.rb dependency to 0.6.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source :rubygems
 
 gem "json", "1.6.6" # for json
 gem "cabin", "0.4.4" # for logging
-gem "http_parser.rb", "0.5.3" # for http request/response parsing
+gem "http_parser.rb", "~> 0.6" # for http request/response parsing
 gem "addressable", "2.2.6"  # because stdlib URI is terrible
 gem "backports", "2.6.2" # for hacking stuff in to ruby <1.9
 gem "minitest" # for unit tests, latest of this is fine

--- a/ftw.gemspec
+++ b/ftw.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.license = "Apache License (2.0)"
 
   spec.add_dependency("cabin", ">0") # for logging, latest is fine for now
-  spec.add_dependency("http_parser.rb", "0.5.3") # for http request/response parsing
+  spec.add_dependency("http_parser.rb", "~> 0.6") # for http request/response parsing
   spec.add_dependency("addressable")  # because stdlib URI is terrible
   spec.add_dependency("backports", ">= 2.6.2") # for hacking stuff into ruby <1.9
   spec.add_development_dependency("minitest", ">0") # for unit tests, latest of this is fine


### PR DESCRIPTION
`make test` still works
