### PR TITLE
Update agent.rb

### DIFF
--- a/lib/ftw/agent.rb
+++ b/lib/ftw/agent.rb
@@ -370,6 +370,9 @@ class FTW::Agent
     need_ssl_ca_certs = true
 
     @certificate_store = OpenSSL::X509::Store.new
+    # Load in the operating systems default certs
+    @certificate_store.set_default_paths
+    
     if configuration[SSL_USE_DEFAULT_CERTS]
       if File.readable?(OpenSSL::X509::DEFAULT_CERT_FILE)
         @logger.debug("Adding default certificate file",


### PR DESCRIPTION
Hi, 
For some reason, when my certificate file is read from `OpenSSL::X509::DEFAULT_CERT_FILE` (which in my case is /usr/lib/jvm/java-1.8.0-oracle-1.8.0.45.x86_64/jre/lib/security/cacerts) I get `self signed certificate in chain` errors.

After many, many hours of googling i discovered `OpenSSL::X509::Store.new.set_default_paths` which loads in the systems default stores (see http://ruby-doc.org/stdlib-2.0.0/libdoc/openssl/rdoc/OpenSSL/X509/Store.html) 

Therefore I've added @certificate_store.set_default_paths to load in the OS default cert paths.

I'd appreciate it if you could merge + bump the version on this as at the moment, I'm unable to use the logstash https output with a self signed certificate that is perfectly valid as I trust the CA.

Without this function:
```
# /opt/logstash/vendor/jruby/bin/jruby doctor.rb
/opt/logstash/vendor/jruby/bin/jruby (1.9.3
JRuby-OpenSSL 0.9.7: /usr/lib/jvm/java-1.8.0-oracle-1.8.0.45.x86_64/jre/lib/security
SSL_CERT_DIR=""
SSL_CERT_FILE=""

HEAD https://**intentionally omitted**:443
OpenSSL::SSL::SSLError: certificate verify failed

The server presented a certificate that could not be verified:
  subject: /O=hp.com/OU=IT Infrastructure/C=US/O=Hewlett-Packard Company/CN=Hewlett-Packard Private Class 2 Certification Authority
  issuer: /O=hp.com/OU=IT Infrastructure/C=US/O=Hewlett-Packard Company/CN=Hewlett-Packard Private Class 2 Certification Authority
  error code 19: self signed certificate in certificate chain
```

With it:
```
# /opt/logstash/vendor/jruby/bin/jruby doctor.rb
/opt/logstash/vendor/jruby/bin/jruby (1.9.3
JRuby-OpenSSL 0.9.7: /usr/lib/jvm/java-1.8.0-oracle-1.8.0.45.x86_64/jre/lib/security
SSL_CERT_DIR=""
SSL_CERT_FILE=""
/usr/lib/jvm/java-1.8.0-oracle-1.8.0.45.x86_64/jre/lib/security/cacerts

HEAD https://**intentionally omitted**:443
OK
```