### PR TITLE
Pin version of "addressable" dependency

### DIFF
--- a/ftw.gemspec
+++ b/ftw.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency("cabin", ">0") # for logging, latest is fine for now
   spec.add_dependency("http_parser.rb", "~> 0.6") # for http request/response parsing
-  spec.add_dependency("addressable")  # because stdlib URI is terrible
+  spec.add_dependency("addressable", "~> 2.2")  # because stdlib URI is terrible
   spec.add_dependency("backports", ">= 2.6.2") # for hacking stuff into ruby <1.9
   spec.add_development_dependency("minitest", ">0") # for unit tests, latest of this is fine
 


### PR DESCRIPTION
As of 2016-11-04, a non-versioned dependency on `addressable` pulls in version `1.5.0`, which [does not support Ruby 1.9](https://github.com/sporkmonger/addressable/blob/addressable-2.5.0/CHANGELOG.md#addressable-250) (due to the transitive dependency on `public_suffix`).

This patch holds the version of addressable to `2.2.x`, like in the Gemfile.

🍻 