### PR TITLE
Correctly enforce use of "addressable" < 2.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source :rubygems
 gem "json", "1.6.6" # for json
 gem "cabin", "0.4.4" # for logging
 gem "http_parser.rb", "~> 0.6" # for http request/response parsing
-gem "addressable", "2.2.6"  # because stdlib URI is terrible
+gem "addressable", "~> 2.2.0"  # because stdlib URI is terrible
 gem "backports", "2.6.2" # for hacking stuff in to ruby <1.9
 gem "minitest" # for unit tests, latest of this is fine
 

--- a/ftw.gemspec
+++ b/ftw.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency("cabin", ">0") # for logging, latest is fine for now
   spec.add_dependency("http_parser.rb", "~> 0.6") # for http request/response parsing
-  spec.add_dependency("addressable", "~> 2.2")  # because stdlib URI is terrible
+  spec.add_dependency("addressable", "~> 2.2.0")  # because stdlib URI is terrible
   spec.add_dependency("backports", ">= 2.6.2") # for hacking stuff into ruby <1.9
   spec.add_development_dependency("minitest", ">0") # for unit tests, latest of this is fine
 


### PR DESCRIPTION
Sorry Jordan,

In 45ddf453483b92196ec0fbcb3a17516de602aa2a, I completely failed to understand the subtleties of the "twiddle whacker", thus allowing `addressable` to be installed at any version less than `3.0`. That's precisely what I didn't want.

Here is a correctly _twiddle-whacked_ variant.