### PR TITLE
Update addressable gem to 2.3.x.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source :rubygems
 gem "json", "1.6.6" # for json
 gem "cabin", "0.4.4" # for logging
 gem "http_parser.rb", "~> 0.6" # for http request/response parsing
-gem "addressable", "~> 2.2.0"  # because stdlib URI is terrible
+gem "addressable", "~> 2.3.0"  # because stdlib URI is terrible
 gem "backports", "2.6.2" # for hacking stuff in to ruby <1.9
 gem "minitest" # for unit tests, latest of this is fine
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    addressable (2.2.6)
+    addressable (2.3.8)
     awesome_print (1.2.0)
     backports (2.6.2)
     cabin (0.4.4)
@@ -57,7 +57,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  addressable (= 2.2.6)
+  addressable (~> 2.3.0)
   awesome_print
   backports (= 2.6.2)
   cabin (= 0.4.4)
@@ -73,4 +73,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.11.2
+   1.14.5

--- a/ftw.gemspec
+++ b/ftw.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency("cabin", ">0") # for logging, latest is fine for now
   spec.add_dependency("http_parser.rb", "~> 0.6") # for http request/response parsing
-  spec.add_dependency("addressable", "~> 2.2.0")  # because stdlib URI is terrible
+  spec.add_dependency("addressable", "~> 2.3.0")  # because stdlib URI is terrible
   spec.add_dependency("backports", ">= 2.6.2") # for hacking stuff into ruby <1.9
   spec.add_development_dependency("minitest", ">0") # for unit tests, latest of this is fine
 


### PR DESCRIPTION
I am trying to use the logstash websockets input (https://github.com/logstash-plugins/logstash-input-websocket) and have gem conflict errors because they are using addressable 2.3.8 else where.

So this PR just locks addressable to 2.3.x from 2.2.x.