### PR TITLE
Update dependency on addressable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source :rubygems
 gem "json", "1.6.6" # for json
 gem "cabin", "0.4.4" # for logging
 gem "http_parser.rb", "~> 0.6" # for http request/response parsing
-gem "addressable", "~> 2.2.0"  # because stdlib URI is terrible
+gem "addressable", "~> 2.3.8"  # because stdlib URI is terrible
 gem "backports", "2.6.2" # for hacking stuff in to ruby <1.9
 gem "minitest" # for unit tests, latest of this is fine
 

--- a/ftw.gemspec
+++ b/ftw.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency("cabin", ">0") # for logging, latest is fine for now
   spec.add_dependency("http_parser.rb", "~> 0.6") # for http request/response parsing
-  spec.add_dependency("addressable", "~> 2.2.0")  # because stdlib URI is terrible
+  spec.add_dependency("addressable", "~> 2.3.8")  # because stdlib URI is terrible
   spec.add_dependency("backports", ">= 2.6.2") # for hacking stuff into ruby <1.9
   spec.add_development_dependency("minitest", ">0") # for unit tests, latest of this is fine
 

--- a/lib/ftw/version.rb
+++ b/lib/ftw/version.rb
@@ -3,5 +3,5 @@ require "ftw/namespace"
 # :nodoc:
 module FTW
   # The version of this library
-  VERSION = "0.0.46"
+  VERSION = "0.0.47"
 end


### PR DESCRIPTION
Logstash ships with addressable 2.3.x, the constraints set on ruby-ftw
0.0.46 make it non installable on LS.

And logstash-output-websocket 3.0.3 requires FTW 0.0.46, this version of
the websocket output is the first version to have the documentation
changes.