### PR TITLE
fix: `WebServer#run` should return after we send `WebServer#stop`

### DIFF
--- a/lib/ftw/server.rb
+++ b/lib/ftw/server.rb
@@ -106,7 +106,7 @@ class FTW::Server
     # TODO(sissel): Select on all sockets
     # TODO(sissel): Accept and yield to the block
     stopper = @stopper[0]
-    while true
+    while !@sockets.empty?
       @control_lock.synchronize do
         sockets = @sockets.values + [stopper]
         read, write, error = IO.select(sockets, nil, nil, nil)

--- a/spec/webserver_spec.rb
+++ b/spec/webserver_spec.rb
@@ -1,0 +1,22 @@
+require 'ftw/webserver'
+
+describe "FTW Webserver" do
+  describe '#run' do
+    let(:webserver) { FTW::WebServer.new(host, port, &connection_handler) }
+    let(:host) { 'localhost' }
+    let(:port) { 9999 }
+
+    let(:connection_handler) { Proc.new {|request, response| } }
+
+    it 'should return when the webserver has been stopped' do
+      webserver_thread = Thread.new { webserver.run }
+      sleep 0.2 # wait for server to start
+      webserver.stop
+
+      webserver_thread.join(10) || begin
+        fail("Webserver#run failed to return after 10s")
+        webserver_thread.kill
+      end
+    end
+  end
+end


### PR DESCRIPTION
Because `FTW::Server#each_connection` runs in a `while true` loop, breaking
the current iteration when we encounter a message on our stop pipe is not
enough; it allows the thread sending `FTW::Server#stop` to acquire the lock
and clean up our bound sockets, but the loop continues indefinitely.

Instead, only run the loop if we still have sockets to listen on.