### PR TITLE
Unsupported http versions

### DIFF
--- a/lib/ftw/http/message.rb
+++ b/lib/ftw/http/message.rb
@@ -21,6 +21,9 @@ module FTW::HTTP::Message
   # HTTP Versions that are valid.
   VALID_VERSIONS = [1.0, 1.1]
 
+  # For backward-compatibility, this exception inherits from ArgumentError
+  UnsupportedHTTPVersion = Class.new(ArgumentError)
+
   private
 
   # A new HTTP message.
@@ -101,7 +104,7 @@ module FTW::HTTP::Message
     ver = ver.to_f if !ver.is_a?(Float)
 
     if !VALID_VERSIONS.include?(ver)
-      raise ArgumentError.new("#{self.class.name}#version = #{ver.inspect} is" \
+      raise UnsupportedHTTPVersion.new("#{self.class.name}#version = #{ver.inspect} is" \
         "invalid. It must be a number, one of #{VALID_VERSIONS.join(", ")}")
     end
     @version = ver

--- a/lib/ftw/webserver.rb
+++ b/lib/ftw/webserver.rb
@@ -49,6 +49,8 @@ class FTW::WebServer
         # Connection EOF'd or errored before we finished reading a full HTTP
         # message, shut it down.
         break
+      rescue FTW::HTTP::Message::UnsupportedHTTPVersion
+        break
       end
 
       if request["Content-Length"] || request["Transfer-Encoding"]

--- a/spec/webserver_spec.rb
+++ b/spec/webserver_spec.rb
@@ -18,5 +18,36 @@ describe "FTW Webserver" do
         fail("Webserver#run failed to return after 10s")
       end
     end
+
+    context 'when receiving a message claiming to be an unsupported HTTP version' do
+      it "doesn't crash" do
+        require 'socket'
+
+        webserver_thread = Thread.new { webserver.run }
+        sleep 0.2 # wait for plugin to bind to port
+
+        socket = TCPSocket.new('localhost', port)
+        socket.write("GET / HTTP/0.9\r\n") # party like it's 1991
+        socket.write("\r\n")
+        socket.flush
+        socket.close_write
+        # nothing is written in reply, because we don't know how to support the given protocol
+        expect(socket.read).to be_empty
+
+        # server should still be alive, so send something valid to check
+        socket2 = TCPSocket.new('localhost', port)
+        socket2.write("GET / HTTP/1.1\r\n")
+        socket2.write("\r\n")
+        socket2.flush
+        socket2.close_write
+        expect(socket2.read).to start_with 'HTTP/1.1'
+
+        webserver.stop
+        webserver_thread.join(10) || begin
+          webserver_thread.kill
+          fail("Webserver#run failed to return after 10s")
+        end
+      end
+    end
   end
 end

--- a/spec/webserver_spec.rb
+++ b/spec/webserver_spec.rb
@@ -14,8 +14,8 @@ describe "FTW Webserver" do
       webserver.stop
 
       webserver_thread.join(10) || begin
-        fail("Webserver#run failed to return after 10s")
         webserver_thread.kill
+        fail("Webserver#run failed to return after 10s")
       end
     end
   end


### PR DESCRIPTION
When we receive a message with an unsupported HTTP version instead of throwing an `ArgumentError`, which blows through our stack and crashes the whole server, behave in the same way we do if the request cannot be parsed: emit an empty response and move on.

