### PR TITLE
Bump addressable to 2-4 min

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source :rubygems
 gem "json" # for json
 gem "cabin", "0.4.4" # for logging
 gem "http_parser.rb", "~> 0.6" # for http request/response parsing
-gem "addressable", "~> 2.3.8"  # because stdlib URI is terrible
+gem "addressable", ">= 2.4"  # because stdlib URI is terrible
 gem "backports", "2.6.2" # for hacking stuff in to ruby <1.9
 gem "minitest" # for unit tests, latest of this is fine
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,8 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    addressable (2.3.8)
+    addressable (2.6.0)
+      public_suffix (>= 2.0.2, < 4.0)
     awesome_print (1.8.0)
     backports (2.6.2)
     cabin (0.4.4)
@@ -25,6 +26,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
       spoon (~> 0.0)
+    public_suffix (3.1.1)
     rack (2.0.4)
     rack-protection (2.0.0)
       rack
@@ -57,7 +59,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  addressable (~> 2.3.8)
+  addressable (>= 2.4)
   awesome_print
   backports (= 2.6.2)
   cabin (= 0.4.4)
@@ -73,4 +75,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.15.4
+   2.0.2

--- a/ftw.gemspec
+++ b/ftw.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency("cabin", ">0") # for logging, latest is fine for now
   spec.add_dependency("http_parser.rb", "~> 0.6") # for http request/response parsing
-  spec.add_dependency("addressable", "~> 2.3.8")  # because stdlib URI is terrible
+  spec.add_dependency("addressable", ">= 2.4")  # because stdlib URI is terrible
   spec.add_dependency("backports", ">= 2.6.2") # for hacking stuff into ruby <1.9
   spec.add_development_dependency("minitest", ">0") # for unit tests, latest of this is fine
 
@@ -32,4 +32,3 @@ Gem::Specification.new do |spec|
   spec.email = ["jls@semicomplete.com"]
   spec.homepage = "http://github.com/jordansissel/ruby-ftw"
 end
-

--- a/lib/ftw/version.rb
+++ b/lib/ftw/version.rb
@@ -3,5 +3,5 @@ require "ftw/namespace"
 # :nodoc:
 module FTW
   # The version of this library
-  VERSION = "0.0.47"
+  VERSION = "0.0.49"
 end


### PR DESCRIPTION
Should fix #42 

Bumps the addressable dependency to >= 2.4. This should make us compatible with logstash (and logstash plugins) for 7.x and up.

Passes tests locally (after some fudging with the documentation of methods and constants, which is beyond the scope of this patch):

```
mindbat-pro-elastic:ruby-ftw rontoland$ make test
sh notify-failure.sh ruby test/all.rb
Loading tests from test/docs.rb
Loading tests from test/ftw/crlf.rb
Loading tests from test/ftw/singleton.rb
Loading tests from test/ftw/http/headers.rb
Loading tests from test/ftw/http/dns.rb
Loading tests from test/ftw/protocol.rb
Coverage report generated for Unit Tests to /Users/rontoland/Code/ruby-ftw/coverage. 115 / 340 LOC (33.82%) covered.
Run options: --seed 2829

# Running:

[warn]: @param tag has unknown parameter name:  
    in file `/Users/rontoland/Code/ruby-ftw/lib/ftw/agent.rb' near line 278
[warn]: @param tag has unknown parameter name: a 
    in file `/Users/rontoland/Code/ruby-ftw/lib/ftw/http/headers.rb' near line 24
[warn]: @param tag has unknown parameter name: the 
    in file `/Users/rontoland/Code/ruby-ftw/lib/ftw/http/headers.rb' near line 34
[warn]: @param tag has unknown parameter name: the 
    in file `/Users/rontoland/Code/ruby-ftw/lib/ftw/http/headers.rb' near line 34
[warn]: @param tag has unknown parameter name: the 
    in file `/Users/rontoland/Code/ruby-ftw/lib/ftw/http/message.rb' near line 38
[warn]: @param tag has unknown parameter name: the 
    in file `/Users/rontoland/Code/ruby-ftw/lib/ftw/http/message.rb' near line 46
[warn]: @param tag has unknown parameter name: the 
    in file `/Users/rontoland/Code/ruby-ftw/lib/ftw/http/message.rb' near line 46
[warn]: @param tag has unknown parameter name: the 
    in file `/Users/rontoland/Code/ruby-ftw/lib/ftw/websocket/parser.rb' near line 77
...............

Finished in 0.383353s, 39.1284 runs/s, 65.2140 assertions/s.

15 runs, 25 assertions, 0 failures, 0 errors, 0 skips
```